### PR TITLE
naggen 'network/client' fix

### DIFF
--- a/ext/nagios/naggen
+++ b/ext/nagios/naggen
@@ -5,7 +5,6 @@ require 'puppet/rails'
 require 'puppet/file_bucket/dipper'
 require 'puppet/rails/resource'
 require 'puppet/rails/param_value'
-require 'puppet/network/client'
 require 'puppet/parser/collector'
 require 'puppet/provider/naginator'
 


### PR DESCRIPTION
I just now noticed that there was "Code insufficient" status. Sorry for that.
Also i dont' recall forking and/or sending any patches just the fixed application.
Regarding 'network/client' dependency, naggen doesn't need it at all. Have no idea why it's there.
